### PR TITLE
test: Add testing harness for Cloud DNS

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -1,0 +1,36 @@
+#
+---
+driver:
+  name: terraform
+  command_timeout: 600
+  verify_version: true
+  root_module_directory: test/fixtures/root
+
+provisioner:
+  name: terraform
+
+verifier:
+  name: terraform
+  color: true
+  systems:
+    - name: google
+      backend: gcp
+
+platforms:
+  - name: default
+    driver:
+      variables:
+        name: restricted-apis-default
+  - name: no-overrides
+    driver:
+      variables:
+        name: restricted-apis-no-overrides
+        overrides: '[]'
+  - name: labels
+    driver:
+      variables:
+        name: restricted-apis-labels
+        labels: '{scenario=\"labels\"}'
+
+suites:
+  - name: restricted-apis-dns

--- a/test/fixtures/root/main.tf
+++ b/test/fixtures/root/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.2"
+}
+
+resource "google_compute_network" "test" {
+  project                 = var.project_id
+  name                    = var.name
+  description             = "Test VPC network for restricted-api DNS testing"
+  auto_create_subnetworks = false
+  routing_mode            = "REGIONAL"
+}
+
+module "test" {
+  source     = "./../../../"
+  project_id = var.project_id
+  name       = var.name
+  overrides  = var.overrides
+  labels     = var.labels
+  network_self_links = [
+    google_compute_network.test.self_link,
+  ]
+}

--- a/test/fixtures/root/outputs.tf
+++ b/test/fixtures/root/outputs.tf
@@ -1,0 +1,13 @@
+output "network_self_link" {
+  value = google_compute_network.test.self_link
+}
+
+output "overrides_json" {
+  value = jsonencode(var.overrides)
+}
+
+output "labels_json" {
+  value = jsonencode(merge({
+    module = "restricted-apis-dns"
+  }, var.labels))
+}

--- a/test/fixtures/root/variables.tf
+++ b/test/fixtures/root/variables.tf
@@ -1,0 +1,20 @@
+variable "project_id" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "overrides" {
+  type = list(string)
+  default = [
+    "gcr.io",
+    "pkg.dev",
+  ]
+}
+
+variable "labels" {
+  type    = map(string)
+  default = {}
+}

--- a/test/integration/restricted-apis-dns/controls/records.rb
+++ b/test/integration/restricted-apis-dns/controls/records.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'json'
+
+EXPECTED_CNAME_RRS = ['restricted.googleapis.com.'].freeze
+EXPECTED_A_RRS = ['199.36.153.4', '199.36.153.5', '199.36.153.6', '199.36.153.7'].freeze
+
+control 'records' do
+  title 'Ensure googleapis.com Cloud DNS zone has the correct records'
+  impact 1.0
+  name = input('input_name')
+  project_id = input('input_project_id')
+
+  describe google_dns_resource_record_set(project: project_id, name: '*.googleapis.com.', type: 'CNAME',
+                                          managed_zone: "#{name}-googleapis") do
+    it { should exist }
+    its('ttl') { should eq 300 }
+    its('target') { should cmp EXPECTED_CNAME_RRS }
+  end
+
+  describe google_dns_resource_record_set(project: project_id, name: 'restricted.googleapis.com.', type: 'A',
+                                          managed_zone: "#{name}-googleapis") do
+    it { should exist }
+    its('ttl') { should eq 300 }
+    its('target') { should cmp EXPECTED_A_RRS }
+  end
+end
+
+control 'override-records' do
+  title 'Ensure each additional Cloud DNS zone has the correct records'
+  impact 1.0
+  name = input('input_name')
+  project_id = input('input_project_id')
+  overrides = JSON.parse(input('output_overrides_json'), { symbolize_names: false })
+
+  only_if('No override zones specified') do
+    !overrides.empty?
+  end
+
+  zones = overrides.map do |n|
+    { "#{name}-#{n.sub(/[^a-zA-Z0-9]/, '-')}" => n.delete_suffix('.') }
+  end.reduce(:merge)
+  zones.each do |zone, domain|
+    describe google_dns_resource_record_set(project: project_id, name: "*.#{domain}.", type: 'CNAME',
+                                            managed_zone: zone) do
+      it { should exist }
+      its('ttl') { should eq 300 }
+      its('target') { should cmp EXPECTED_CNAME_RRS }
+    end
+    describe google_dns_resource_record_set(project: project_id, name: "#{domain}.", type: 'A', managed_zone: zone) do
+      it { should exist }
+      its('ttl') { should eq 300 }
+      its('target') { should cmp EXPECTED_A_RRS }
+    end
+  end
+end

--- a/test/integration/restricted-apis-dns/controls/zones.rb
+++ b/test/integration/restricted-apis-dns/controls/zones.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'json'
+
+control 'googleapis' do
+  title 'Ensure Cloud DNS zone overriding googleapis.com meets expectations'
+  impact 1.0
+  name = input('input_name')
+  project_id = input('input_project_id')
+  network_self_link = input('output_network_self_link')
+  labels = JSON.parse(input('output_labels_json'), { symbolize_names: false })
+
+  describe google_dns_managed_zone(project: project_id, zone: "#{name}-googleapis") do
+    it { should exist }
+    its('name') { should cmp "#{name}-googleapis" }
+    its('description') { should cmp 'Override googleapis.com domain to use restricted.googleapis.com endpoints' }
+    its('dns_name') { should cmp 'googleapis.com.' }
+    its('visibility') { should cmp 'private' }
+    its('private_visibility_config') { should_not be_nil }
+    its('private_visibility_config.networks') { should_not be_empty }
+    its('private_visibility_config.networks.first.network_url') { should cmp network_self_link }
+    its('labels') { should cmp labels }
+  end
+end
+
+control 'overrides' do
+  title 'Ensure additional Cloud DNS zone meets expectations'
+  impact 1.0
+  name = input('input_name')
+  project_id = input('input_project_id')
+  overrides = JSON.parse(input('output_overrides_json'), { symbolize_names: false })
+  network_self_link = input('output_network_self_link')
+  labels = JSON.parse(input('output_labels_json'), { symbolize_names: false })
+
+  only_if('No override zones specified') do
+    !overrides.empty?
+  end
+
+  zones = overrides.map do |n|
+    { "#{name}-#{n.sub(/[^a-zA-Z0-9]/, '-')}" => n.delete_suffix('.') }
+  end.reduce(:merge)
+  zones.each do |zone, domain|
+    describe google_dns_managed_zone(project: project_id, zone: zone) do
+      it { should exist }
+      its('description') { should cmp "Override #{domain} domain to use restricted.googleapis.com private endpoints" }
+      its('dns_name') { should cmp "#{domain}." }
+      its('visibility') { should cmp 'private' }
+      its('private_visibility_config') { should_not be_nil }
+      its('private_visibility_config.networks') { should_not be_empty }
+      its('private_visibility_config.networks.first.network_url') { should cmp network_self_link }
+      its('labels') { should cmp labels }
+    end
+  end
+end

--- a/test/integration/restricted-apis-dns/inspec.yml
+++ b/test/integration/restricted-apis-dns/inspec.yml
@@ -1,0 +1,28 @@
+---
+name: restricted-apis-dns
+title: Verifies that Cloud DNS zones for restricted API meet expectations
+maintainer: Matthew Emes <memes@matthewemes.com>
+license: Apache-2.0
+version: 1.0.0
+supports:
+  - platform: gcp
+depends:
+  - name: inspec-gcp
+    git: https://github.com/inspec/inspec-gcp.git
+    tag: v1.10.39
+inputs:
+  - name: input_project_id
+    type: string
+    required: true
+  - name: input_name
+    type: string
+    required: true
+  - name: output_overrides_json
+    type: string
+    required: true
+  - name: output_labels_json
+    type: string
+    required: true
+  - name: output_network_self_link
+    type: string
+    required: true

--- a/test/reports/.gitkeep
+++ b/test/reports/.gitkeep
@@ -1,0 +1,1 @@
+# Making sure the reports directory exists.


### PR DESCRIPTION
Provides a basic testing harness to verify that each Cloud DNS zone has the appropriate config and records.

Closes #7.