### PR TITLE
test: Kitchen-terraform v7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,12 @@
 ruby '3.3.6'
 
 source 'https://rubygems.org/'
-gem 'kitchen-terraform', '~> 6.1.0'
+gem 'kitchen-terraform', '~> 7.0.2'
+# Nori 2.7 causes problems with inspec-gcp, so pin to 2.6
+# See https://github.com/inspec/inspec-gcp/issues/596
+gem 'nori', '~> 2.6.0'
 group :dev do
   gem 'reek', '~> 6.3.0', require: false
-  gem 'rubocop', '~> 1.65.0', require: false
+  # Transitive dependency on rubocop v1.25.1 via kitchen-terraform
+  # gem 'rubocop', '~> 1.67.0', require: false
 end

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -2,8 +2,11 @@
 ---
 driver:
   name: terraform
-  command_timeout: 600
   verify_version: true
+
+transport:
+  name: terraform
+  command_timeout: 600
   root_module_directory: test/fixtures/root
 
 provisioner:

--- a/test/integration/private-apis-dns/controls/records.rb
+++ b/test/integration/private-apis-dns/controls/records.rb
@@ -10,23 +10,23 @@ control 'records' do
   title 'Ensure googleapis.com Cloud DNS zone has the correct records'
   impact 1.0
   name = input('input_name')
-  project_id = input('input_project_id')
+  project = input('input_project_id')
 
-  describe google_dns_resource_record_set(project: project_id, name: '*.googleapis.com.', type: 'CNAME',
+  describe google_dns_resource_record_set(project:, name: '*.googleapis.com.', type: 'CNAME',
                                           managed_zone: "#{name}-googleapis") do
     it { should exist }
     its('ttl') { should eq 300 }
     its('target') { should cmp EXPECTED_CNAME_RRS }
   end
 
-  describe google_dns_resource_record_set(project: project_id, name: 'private.googleapis.com.', type: 'A',
+  describe google_dns_resource_record_set(project:, name: 'private.googleapis.com.', type: 'A',
                                           managed_zone: "#{name}-googleapis") do
     it { should exist }
     its('ttl') { should eq 300 }
     its('target') { should cmp EXPECTED_A_RRS }
   end
 
-  describe google_dns_resource_record_set(project: project_id, name: 'private.googleapis.com.', type: 'AAAA',
+  describe google_dns_resource_record_set(project:, name: 'private.googleapis.com.', type: 'AAAA',
                                           managed_zone: "#{name}-googleapis") do
     it { should exist }
     its('ttl') { should eq 300 }
@@ -39,7 +39,7 @@ control 'override-records' do
   title 'Ensure each additional Cloud DNS zone has the correct records'
   impact 1.0
   name = input('input_name')
-  project_id = input('input_project_id')
+  project = input('input_project_id')
   overrides = JSON.parse(input('output_overrides_json'), { symbolize_names: false })
 
   only_if('No override zones specified') do
@@ -50,20 +50,20 @@ control 'override-records' do
     { "#{name}-#{n.sub(/[^a-zA-Z0-9]/, '-')}" => n.delete_suffix('.') }
   end.reduce(:merge)
   zones.each do |zone, domain|
-    describe google_dns_resource_record_set(project: project_id, name: "*.#{domain}.", type: 'CNAME',
+    describe google_dns_resource_record_set(project:, name: "*.#{domain}.", type: 'CNAME',
                                             managed_zone: zone) do
       it { should exist }
       its('ttl') { should eq 300 }
       its('target') { should cmp EXPECTED_CNAME_RRS }
     end
 
-    describe google_dns_resource_record_set(project: project_id, name: "#{domain}.", type: 'A', managed_zone: zone) do
+    describe google_dns_resource_record_set(project:, name: "#{domain}.", type: 'A', managed_zone: zone) do
       it { should exist }
       its('ttl') { should eq 300 }
       its('target') { should cmp EXPECTED_A_RRS }
     end
 
-    describe google_dns_resource_record_set(project: project_id, name: "#{domain}.", type: 'AAAA',
+    describe google_dns_resource_record_set(project:, name: "#{domain}.", type: 'AAAA',
                                             managed_zone: zone) do
       it { should exist }
       its('ttl') { should eq 300 }

--- a/test/integration/private-apis-dns/controls/zones.rb
+++ b/test/integration/private-apis-dns/controls/zones.rb
@@ -1,23 +1,30 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'rspec/expectations'
+
+RSpec::Matchers.define :be_a_superset_of do |subset|
+  match do |superset|
+    superset >= subset
+  end
+end
 
 control 'googleapis' do
   title 'Ensure Cloud DNS zone overriding googleapis.com meets expectations'
   impact 1.0
   name = input('input_name')
-  project_id = input('input_project_id')
+  project = input('input_project_id')
   network_self_links = JSON.parse(input('output_network_self_links_json'), { symbolize_names: false }).sort
   labels = JSON.parse(input('output_labels_json'), { symbolize_names: false })
 
-  resource = google_dns_managed_zone(project: project_id, zone: "#{name}-googleapis")
+  resource = google_dns_managed_zone(project:, zone: "#{name}-googleapis")
   describe resource do
     it { should exist }
     its('name') { should cmp "#{name}-googleapis" }
     its('description') { should cmp 'Override googleapis.com domain to use private.googleapis.com endpoints' }
     its('dns_name') { should cmp 'googleapis.com.' }
     its('visibility') { should cmp 'private' }
-    its('labels') { should cmp labels }
+    its('labels') { should be_a_superset_of(labels) }
     its('private_visibility_config') { should_not be_nil }
     if network_self_links.count.positive?
       describe resource.private_visibility_config.networks.map(&:network_url).sort do
@@ -36,7 +43,7 @@ control 'overrides' do
   title 'Ensure additional Cloud DNS zone meets expectations'
   impact 1.0
   name = input('input_name')
-  project_id = input('input_project_id')
+  project = input('input_project_id')
   overrides = JSON.parse(input('output_overrides_json'), { symbolize_names: false })
   network_self_links = JSON.parse(input('output_network_self_links_json'), { symbolize_names: false }).sort
   labels = JSON.parse(input('output_labels_json'), { symbolize_names: false })
@@ -49,13 +56,13 @@ control 'overrides' do
     { "#{name}-#{n.sub(/[^a-zA-Z0-9]/, '-')}" => n.delete_suffix('.') }
   end.reduce(:merge)
   zones.each do |zone, domain|
-    resource = google_dns_managed_zone(project: project_id, zone: zone)
+    resource = google_dns_managed_zone(project:, zone:)
     describe resource do
       it { should exist }
       its('description') { should cmp "Override #{domain} domain to use private.googleapis.com private endpoints" }
       its('dns_name') { should cmp "#{domain}." }
       its('visibility') { should cmp 'private' }
-      its('labels') { should cmp labels }
+      its('labels') { should be_a_superset_of(labels) }
       its('private_visibility_config') { should_not be_nil }
       if network_self_links.count.positive?
         describe resource.private_visibility_config.networks.map(&:network_url).sort do

--- a/test/integration/private-apis-dns/inspec.yml
+++ b/test/integration/private-apis-dns/inspec.yml
@@ -9,7 +9,7 @@ supports:
 depends:
   - name: inspec-gcp
     git: https://github.com/inspec/inspec-gcp.git
-    tag: v1.10.39
+    tag: v1.11.135
 inputs:
   - name: input_project_id
     type: string

--- a/test/integration/restricted-apis-dns/controls/records.rb
+++ b/test/integration/restricted-apis-dns/controls/records.rb
@@ -10,23 +10,23 @@ control 'records' do
   title 'Ensure googleapis.com Cloud DNS zone has the correct records'
   impact 1.0
   name = input('input_name')
-  project_id = input('input_project_id')
+  project = input('input_project_id')
 
-  describe google_dns_resource_record_set(project: project_id, name: '*.googleapis.com.', type: 'CNAME',
+  describe google_dns_resource_record_set(project:, name: '*.googleapis.com.', type: 'CNAME',
                                           managed_zone: "#{name}-googleapis") do
     it { should exist }
     its('ttl') { should eq 300 }
     its('target') { should cmp EXPECTED_CNAME_RRS }
   end
 
-  describe google_dns_resource_record_set(project: project_id, name: 'restricted.googleapis.com.', type: 'A',
+  describe google_dns_resource_record_set(project:, name: 'restricted.googleapis.com.', type: 'A',
                                           managed_zone: "#{name}-googleapis") do
     it { should exist }
     its('ttl') { should eq 300 }
     its('target') { should cmp EXPECTED_A_RRS }
   end
 
-  describe google_dns_resource_record_set(project: project_id, name: 'restricted.googleapis.com.', type: 'AAAA',
+  describe google_dns_resource_record_set(project:, name: 'restricted.googleapis.com.', type: 'AAAA',
                                           managed_zone: "#{name}-googleapis") do
     it { should exist }
     its('ttl') { should eq 300 }
@@ -39,7 +39,7 @@ control 'override-records' do
   title 'Ensure each additional Cloud DNS zone has the correct records'
   impact 1.0
   name = input('input_name')
-  project_id = input('input_project_id')
+  project = input('input_project_id')
   overrides = JSON.parse(input('output_overrides_json'), { symbolize_names: false })
 
   only_if('No override zones specified') do
@@ -50,20 +50,20 @@ control 'override-records' do
     { "#{name}-#{n.sub(/[^a-zA-Z0-9]/, '-')}" => n.delete_suffix('.') }
   end.reduce(:merge)
   zones.each do |zone, domain|
-    describe google_dns_resource_record_set(project: project_id, name: "*.#{domain}.", type: 'CNAME',
+    describe google_dns_resource_record_set(project:, name: "*.#{domain}.", type: 'CNAME',
                                             managed_zone: zone) do
       it { should exist }
       its('ttl') { should eq 300 }
       its('target') { should cmp EXPECTED_CNAME_RRS }
     end
 
-    describe google_dns_resource_record_set(project: project_id, name: "#{domain}.", type: 'A', managed_zone: zone) do
+    describe google_dns_resource_record_set(project:, name: "#{domain}.", type: 'A', managed_zone: zone) do
       it { should exist }
       its('ttl') { should eq 300 }
       its('target') { should cmp EXPECTED_A_RRS }
     end
 
-    describe google_dns_resource_record_set(project: project_id, name: "#{domain}.", type: 'AAAA',
+    describe google_dns_resource_record_set(project:, name: "#{domain}.", type: 'AAAA',
                                             managed_zone: zone) do
       it { should exist }
       its('ttl') { should eq 300 }

--- a/test/integration/restricted-apis-dns/controls/zones.rb
+++ b/test/integration/restricted-apis-dns/controls/zones.rb
@@ -1,23 +1,30 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'rspec/expectations'
+
+RSpec::Matchers.define :be_a_superset_of do |subset|
+  match do |superset|
+    superset >= subset
+  end
+end
 
 control 'googleapis' do
   title 'Ensure Cloud DNS zone overriding googleapis.com meets expectations'
   impact 1.0
   name = input('input_name')
-  project_id = input('input_project_id')
+  project = input('input_project_id')
   network_self_links = JSON.parse(input('output_network_self_links_json'), { symbolize_names: false }).sort
   labels = JSON.parse(input('output_labels_json'), { symbolize_names: false })
 
-  resource = google_dns_managed_zone(project: project_id, zone: "#{name}-googleapis")
+  resource = google_dns_managed_zone(project:, zone: "#{name}-googleapis")
   describe resource do
     it { should exist }
     its('name') { should cmp "#{name}-googleapis" }
     its('description') { should cmp 'Override googleapis.com domain to use restricted.googleapis.com endpoints' }
     its('dns_name') { should cmp 'googleapis.com.' }
     its('visibility') { should cmp 'private' }
-    its('labels') { should cmp labels }
+    its('labels') { should be_a_superset_of(labels) }
     its('private_visibility_config') { should_not be_nil }
     if network_self_links.count.positive?
       describe resource.private_visibility_config.networks.map(&:network_url).sort do
@@ -36,7 +43,7 @@ control 'overrides' do
   title 'Ensure additional Cloud DNS zone meets expectations'
   impact 1.0
   name = input('input_name')
-  project_id = input('input_project_id')
+  project = input('input_project_id')
   overrides = JSON.parse(input('output_overrides_json'), { symbolize_names: false })
   network_self_links = JSON.parse(input('output_network_self_links_json'), { symbolize_names: false }).sort
   labels = JSON.parse(input('output_labels_json'), { symbolize_names: false })
@@ -49,13 +56,13 @@ control 'overrides' do
     { "#{name}-#{n.sub(/[^a-zA-Z0-9]/, '-')}" => n.delete_suffix('.') }
   end.reduce(:merge)
   zones.each do |zone, domain|
-    resource = google_dns_managed_zone(project: project_id, zone: zone)
+    resource = google_dns_managed_zone(project:, zone:)
     describe resource do
       it { should exist }
       its('description') { should cmp "Override #{domain} domain to use restricted.googleapis.com private endpoints" }
       its('dns_name') { should cmp "#{domain}." }
       its('visibility') { should cmp 'private' }
-      its('labels') { should cmp labels }
+      its('labels') { should be_a_superset_of(labels) }
       its('private_visibility_config') { should_not be_nil }
       if network_self_links.count.positive?
         describe resource.private_visibility_config.networks.map(&:network_url).sort do

--- a/test/integration/restricted-apis-dns/inspec.yml
+++ b/test/integration/restricted-apis-dns/inspec.yml
@@ -9,7 +9,7 @@ supports:
 depends:
   - name: inspec-gcp
     git: https://github.com/inspec/inspec-gcp.git
-    tag: v1.10.39
+    tag: v1.11.135
 inputs:
   - name: input_project_id
     type: string


### PR DESCRIPTION
- Update kitchen-terraform to v7.0.2, and removes explicit rubocop
- Update inspec-gcp to v1.11.135
- Update controls to compare GCP labels includes the specific labels instead of cmp; Google provider can auto-add labels that break simple comparison
- Rubocop lint fixes